### PR TITLE
Use OpenPhotoFrame as android laucher app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,8 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.HOME"/>
+                <category android:name="android.intent.category.DEFAULT"/>                
             </intent-filter>
         </activity>
         <!-- Boot Receiver for autostart -->


### PR DESCRIPTION
I am using this app as the android launcher app. No idea if this is a good idea overall but I like the concept that there is no other interface when launching the tablet and it can be implemented just by setting these flags in the manifest. 