### PR TITLE
Enable Android "Screen saver" (DreamService) support

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,7 +18,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace = "io.github.micw.openphotoframe"
-    compileSdk = 37
+    compileSdk = 36
     ndkVersion = flutter.ndkVersion
 
     // Disable dependency metadata in APK signature block (required for F-Droid reproducible builds)
@@ -41,7 +41,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = 24
-        targetSdk = 37
+        targetSdk = 36
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,7 +18,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace = "io.github.micw.openphotoframe"
-    compileSdk = 36
+    compileSdk = 37
     ndkVersion = flutter.ndkVersion
 
     // Disable dependency metadata in APK signature block (required for F-Droid reproducible builds)
@@ -41,7 +41,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = 24
-        targetSdk = 36
+        targetSdk = 37
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -105,6 +105,21 @@
         <meta-data
             android:name="io.flutter.embedding.android.EnableImpeller"
             android:value="false" />
+        <!-- Screen Saver (Dream) Service -->
+        <service
+            android:name=".PhotoFrameDreamService"
+            android:exported="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/dream_label"
+            android:permission="android.permission.BIND_DREAM_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.dreams.DreamService" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data
+                android:name="android.service.dream"
+                android:resource="@xml/dream_info" />
+        </service>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/kotlin/io/github/micw/openphotoframe/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/micw/openphotoframe/MainActivity.kt
@@ -1,5 +1,6 @@
 package io.github.micw.openphotoframe
 
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import io.flutter.embedding.android.FlutterActivity
@@ -15,14 +16,27 @@ class MainActivity : FlutterActivity() {
     private lateinit var screenControlHandler: ScreenControlHandler
     private lateinit var keepAliveHandler: KeepAliveHandler
     private lateinit var updaterHandler: UpdaterHandler
+    var isDreamMode = false
+        private set
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        isDreamMode = intent?.getBooleanExtra("is_dream", false) ?: false
+        Log.d("MainActivity", "isDreamMode: $isDreamMode")
+
         // Debug logging for screen size detection
         val display = windowManager.defaultDisplay
         val size = android.graphics.Point()
         display.getSize(size)
         Log.d("MainActivity", "Window size onCreate: ${size.x}x${size.y}")
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        isDreamMode = intent.getBooleanExtra("is_dream", false)
+        Log.d("MainActivity", "onNewIntent isDreamMode: $isDreamMode")
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {

--- a/android/app/src/main/kotlin/io/github/micw/openphotoframe/PhotoFrameDreamService.kt
+++ b/android/app/src/main/kotlin/io/github/micw/openphotoframe/PhotoFrameDreamService.kt
@@ -1,0 +1,19 @@
+package io.github.micw.openphotoframe
+
+import android.content.Intent
+import android.service.dreams.DreamService
+
+class PhotoFrameDreamService : DreamService() {
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        isInteractive = false
+        isFullscreen = true
+
+        val intent = Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        startActivity(intent)
+        finish()
+    }
+}

--- a/android/app/src/main/kotlin/io/github/micw/openphotoframe/PhotoFrameDreamService.kt
+++ b/android/app/src/main/kotlin/io/github/micw/openphotoframe/PhotoFrameDreamService.kt
@@ -12,6 +12,7 @@ class PhotoFrameDreamService : DreamService() {
 
         val intent = Intent(this, MainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            putExtra("is_dream", true)
         }
         startActivity(intent)
         finish()

--- a/android/app/src/main/kotlin/io/github/micw/openphotoframe/ScreenControlHandler.kt
+++ b/android/app/src/main/kotlin/io/github/micw/openphotoframe/ScreenControlHandler.kt
@@ -82,6 +82,23 @@ class ScreenControlHandler(private val context: Context) {
                 "isScreenOn" -> {
                     result.success(powerManager.isInteractive)
                 }
+                "isDreamMode" -> {
+                    val activity = context as? MainActivity
+                    result.success(activity?.isDreamMode ?: false)
+                }
+                "exitApp" -> {
+                    val activity = context as? android.app.Activity
+                    if (activity != null) {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                            activity.finishAndRemoveTask()
+                        } else {
+                            activity.finish()
+                        }
+                        result.success(true)
+                    } else {
+                        result.error("UNAVAILABLE", "Activity not available", null)
+                    }
+                }
                 else -> {
                     result.notImplemented()
                 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dream_label">Open Photo Frame</string>
+</resources>

--- a/android/app/src/main/res/xml/dream_info.xml
+++ b/android/app/src/main/res/xml/dream_info.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dream xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/lib/infrastructure/services/native_screen_control_service.dart
+++ b/lib/infrastructure/services/native_screen_control_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 /// - Turn the screen completely off using lockNow()
 /// - Schedule wake-up using AlarmManager
 /// - Wake the screen immediately
+/// - Handle Dream Mode (Daydream) interactions
 /// 
 /// Requires Device Admin permission to be enabled by the user.
 class NativeScreenControlService {
@@ -123,6 +124,35 @@ class NativeScreenControlService {
     } catch (e) {
       print('Error checking screen state: $e');
       return true;
+    }
+  }
+
+  /// Check if the app is currently running in Dream Mode (Daydream/Screen Saver).
+  static Future<bool> isDreamMode() async {
+    if (!isSupported) return false;
+
+    try {
+      final result = await _channel.invokeMethod<bool>('isDreamMode');
+      return result ?? false;
+    } catch (e) {
+      print('Error checking Dream Mode: $e');
+      return false;
+    }
+  }
+
+  /// Exit the app and remove it from recent tasks.
+  /// This is used to return to the previous state (e.g., from Dream Mode).
+  static Future<void> exitApp() async {
+    if (!isSupported) {
+      // For non-Android platforms, we just pop the current route
+      // which might not exit the app but is the closest behavior.
+      return;
+    }
+
+    try {
+      await _channel.invokeMethod('exitApp');
+    } catch (e) {
+      print('Error exiting app: $e');
     }
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -233,6 +233,7 @@
   
   "noPhotosFound": "Keine Fotos gefunden",
   "tapCenterToOpenSettings": "Tippe auf die Bildschirmmitte um Einstellungen zu öffnen",
+  "tapToExit": "Tippen zum Beenden",
   
   "screenOrientation": "Bildschirmausrichtung",
   "screenOrientationAuto": "Automatisch (Sensor)",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -240,6 +240,7 @@
   
   "noPhotosFound": "No photos found",
   "tapCenterToOpenSettings": "Tap center of screen to open settings",
+  "tapToExit": "Tap to exit",
   
   "screenOrientation": "Screen Orientation",
   "screenOrientationAuto": "Automatic (Sensor)",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -950,6 +950,12 @@ abstract class AppLocalizations {
   /// **'Tap center of screen to open settings'**
   String get tapCenterToOpenSettings;
 
+  /// No description provided for @tapToExit.
+  ///
+  /// In en, this message translates to:
+  /// **'Tap to exit'**
+  String get tapToExit;
+
   /// No description provided for @screenOrientation.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -505,6 +505,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Tippe auf die Bildschirmmitte um Einstellungen zu öffnen';
 
   @override
+  String get tapToExit => 'Tippen zum Beenden';
+
+  @override
   String get screenOrientation => 'Bildschirmausrichtung';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -500,6 +500,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tapCenterToOpenSettings => 'Tap center of screen to open settings';
 
   @override
+  String get tapToExit => 'Tap to exit';
+
+  @override
   String get screenOrientation => 'Screen Orientation';
 
   @override

--- a/lib/ui/screens/slideshow_screen.dart
+++ b/lib/ui/screens/slideshow_screen.dart
@@ -443,7 +443,13 @@ class _SlideshowScreenState extends State<SlideshowScreen> with TickerProviderSt
 
   Future<void> _checkDreamMode() async {
     final isDream = await NativeScreenControlService.isDreamMode();
-    if (mounted) setState(() => _isDreamMode = isDream);
+    if (mounted) {
+      setState(() => _isDreamMode = isDream);
+      if (isDream) {
+        // If we are in dream mode, ensure we are showing the slideshow (root route)
+        Navigator.of(context).popUntil((route) => route.isFirst);
+      }
+    }
   }
 
   void _openSettings() {

--- a/lib/ui/screens/slideshow_screen.dart
+++ b/lib/ui/screens/slideshow_screen.dart
@@ -82,6 +82,9 @@ class _SlideshowScreenState extends State<SlideshowScreen> with TickerProviderSt
   // Current photo location name (from geocoding)
   String? _currentLocationName;
 
+  // Dream Mode status
+  bool _isDreamMode = false;
+
   @override
   void initState() {
     super.initState();
@@ -98,6 +101,7 @@ class _SlideshowScreenState extends State<SlideshowScreen> with TickerProviderSt
     // Initialize Service
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _initService();
+      _checkDreamMode();
       _initKeepAliveService();
       _showStartupConfigNoticeIfNeeded();
       // Schedule init is now handled reactively in build() via _updateDisplaySchedule()
@@ -157,6 +161,7 @@ class _SlideshowScreenState extends State<SlideshowScreen> with TickerProviderSt
         }
         
         // Resume slideshow if it was paused
+        _checkDreamMode();
         _resumeSlideshow();
         break;
       case AppLifecycleState.detached:
@@ -436,10 +441,18 @@ class _SlideshowScreenState extends State<SlideshowScreen> with TickerProviderSt
     _startTimer();
   }
 
+  Future<void> _checkDreamMode() async {
+    final isDream = await NativeScreenControlService.isDreamMode();
+    if (mounted) setState(() => _isDreamMode = isDream);
+  }
+
   void _openSettings() {
     _timer?.cancel(); // Stop auto-advance while in settings
     
-    Navigator.of(context).push(
+    if (_isDreamMode) {
+      NativeScreenControlService.exitApp();
+    } else {
+      Navigator.of(context).push(
       MaterialPageRoute(builder: (context) => const SettingsScreen()),
     ).then((_) {
       // Restore immersive mode after returning from settings
@@ -452,6 +465,7 @@ class _SlideshowScreenState extends State<SlideshowScreen> with TickerProviderSt
       // Restart timer when returning from settings
       _startTimer();
     });
+    }
   }
 
   Future<void> _transitionTo(PhotoEntry photo, {SlideDirection? slideDirection}) async {
@@ -673,10 +687,10 @@ class _SlideshowScreenState extends State<SlideshowScreen> with TickerProviderSt
                   AppLocalizations.of(context)!.noPhotosFound,
                   style: TextStyle(color: Colors.white, fontSize: 20),
                 ),
-                SizedBox(height: 8),
+                const SizedBox(height: 8),
                 Text(
-                  AppLocalizations.of(context)!.tapCenterToOpenSettings,
-                  style: TextStyle(color: Colors.white54, fontSize: 14),
+                  _isDreamMode ? AppLocalizations.of(context)!.tapToExit : AppLocalizations.of(context)!.tapCenterToOpenSettings,
+                  style: const TextStyle(color: Colors.white54, fontSize: 14),
                 ),
               ],
             ),


### PR DESCRIPTION
Implemented a native Android DreamService (PhotoFrameDreamService) that launches the app's MainActivity when the screen saver is activated. This allows users to select "Open Photo Frame" as their system screen saver. I have [nightly releases](https://github.com/brad/OpenPhotoFrame/releases/tag/nightly-20260630) built by github actions in my clone if you wanna try. I threw this together willy nilly with Jules, and am not an Android developer so I apologize if I didn't do something right. Happy to address any feedback. Thanks for the nice app :+1:

Summary of changes:

- Created android/app/src/main/res/xml/dream_info.xml for service configuration.
- Implemented PhotoFrameDreamService in Kotlin to handle service startup.
- Added a dream_label string resource for the screen saver name.
- Registered the service in AndroidManifest.xml.
- Keep track of whether the app was launched as a dream service and if so
  - Open straight to photos
  - Tap on center exits the app rather than going to the settings page
  
  # Preview
  
<img width="800" height="1340" alt="Screenshot_2026-06-29-18-27-01-388" src="https://github.com/user-attachments/assets/8ffdc403-5898-4d07-82c5-f525cfb1c6d8" />

