### PR TITLE
Add AM/PM style option for clock overlay (#7)

### DIFF
--- a/assets/config.json
+++ b/assets/config.json
@@ -4,6 +4,10 @@
   "blur_borders": true,
   "sync_interval_minutes": 15,
   "delete_orphaned_files": true,
+  "show_clock": true,
+  "clock_size": "large",
+  "clock_position": "bottomRight",
+  "use_am_pm": false,
   "active_source": "",
   "sources": {
     "nextcloud_link": {

--- a/lib/domain/interfaces/config_provider.dart
+++ b/lib/domain/interfaces/config_provider.dart
@@ -59,6 +59,9 @@ abstract class ConfigProvider extends ChangeNotifier {
   
   String get clockPosition; // 'bottomRight', 'bottomLeft', 'topRight', 'topLeft'
   set clockPosition(String value);
+
+  bool get useAmPm; // Use 12h format with AM/PM
+  set useAmPm(bool value);
   
   // Display schedule settings (day/night mode)
   bool get scheduleEnabled; // Enable day/night schedule

--- a/lib/infrastructure/services/json_config_service.dart
+++ b/lib/infrastructure/services/json_config_service.dart
@@ -383,6 +383,14 @@ class JsonConfigService extends ConfigProvider {
   set clockPosition(String value) {
     _config['clock_position'] = value;
   }
+
+  @override
+  bool get useAmPm => _config['use_am_pm'] ?? false;
+
+  @override
+  set useAmPm(bool value) {
+    _config['use_am_pm'] = value;
+  }
   
   // Display schedule settings (day/night mode)
   @override

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -16,6 +16,8 @@
   "showClockSubtitle": "Uhrzeit auf der Diashow anzeigen",
   "size": "Größe",
   "position": "Position",
+  "useAmPm": "AM/PM verwenden",
+  "useAmPmSubtitle": "Uhr im 12-Stunden-Format mit AM/PM anzeigen",
   
   "sectionPhotoInfo": "Foto-Informationen",
   "showPhotoInfo": "Foto-Info anzeigen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -16,6 +16,8 @@
   "showClockSubtitle": "Display time on slideshow",
   "size": "Size",
   "position": "Position",
+  "useAmPm": "Use AM/PM",
+  "useAmPmSubtitle": "Display clock in 12-hour format with AM/PM",
   
   "sectionPhotoInfo": "Photo Information",
   "showPhotoInfo": "Show Photo Info",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -176,6 +176,18 @@ abstract class AppLocalizations {
   /// **'Position'**
   String get position;
 
+  /// No description provided for @useAmPm.
+  ///
+  /// In en, this message translates to:
+  /// **'Use AM/PM'**
+  String get useAmPm;
+
+  /// No description provided for @useAmPmSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Display clock in 12-hour format with AM/PM'**
+  String get useAmPmSubtitle;
+
   /// No description provided for @sectionPhotoInfo.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -49,6 +49,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get position => 'Position';
 
   @override
+  String get useAmPm => 'AM/PM verwenden';
+
+  @override
+  String get useAmPmSubtitle => 'Uhr im 12-Stunden-Format mit AM/PM anzeigen';
+
+  @override
   String get sectionPhotoInfo => 'Foto-Informationen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -48,6 +48,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get position => 'Position';
 
   @override
+  String get useAmPm => 'Use AM/PM';
+
+  @override
+  String get useAmPmSubtitle => 'Display clock in 12-hour format with AM/PM';
+
+  @override
   String get sectionPhotoInfo => 'Photo Information';
 
   @override

--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -64,6 +64,7 @@ class _SettingsScreenState extends State<SettingsScreen> with WidgetsBindingObse
   late bool _showClock;
   late String _clockSize;
   late String _clockPosition;
+  late bool _useAmPm;
   
   // Photo info settings
   late bool _showPhotoInfo;
@@ -150,6 +151,7 @@ class _SettingsScreenState extends State<SettingsScreen> with WidgetsBindingObse
     _showClock = config.showClock;
     _clockSize = config.clockSize;
     _clockPosition = config.clockPosition;
+    _useAmPm = config.useAmPm;
     
     // Photo info settings
     _showPhotoInfo = config.showPhotoInfo;
@@ -336,6 +338,7 @@ class _SettingsScreenState extends State<SettingsScreen> with WidgetsBindingObse
     config.showClock = _showClock;
     config.clockSize = _clockSize;
     config.clockPosition = _clockPosition;
+    config.useAmPm = _useAmPm;
     
     // Photo info settings
     config.showPhotoInfo = _showPhotoInfo;
@@ -472,6 +475,16 @@ class _SettingsScreenState extends State<SettingsScreen> with WidgetsBindingObse
             _buildClockSizeSelector(),
             const SizedBox(height: 8),
             _buildClockPositionSelector(),
+            const SizedBox(height: 16),
+            SwitchListTile(
+              title: Text(AppLocalizations.of(context)!.useAmPm),
+              subtitle: Text(AppLocalizations.of(context)!.useAmPmSubtitle),
+              secondary: const Icon(Icons.more_time),
+              value: _useAmPm,
+              onChanged: (value) {
+                setState(() => _useAmPm = value);
+              },
+            ),
           ],
           
           const SizedBox(height: 24),

--- a/lib/ui/screens/slideshow_screen.dart
+++ b/lib/ui/screens/slideshow_screen.dart
@@ -727,9 +727,10 @@ class _SlideshowScreenState extends State<SlideshowScreen> with TickerProviderSt
           // 2. Clock Overlay
           if (config.showClock)
             ClockOverlay(
-              key: ValueKey('clock_${config.clockSize}_${config.clockPosition}'),
+              key: ValueKey('clock_${config.clockSize}_${config.clockPosition}_${config.useAmPm}'),
               size: config.clockSize,
               position: config.clockPosition,
+              useAmPm: config.useAmPm,
             ),
 
           // 3. Photo Info Overlay

--- a/lib/ui/widgets/clock_overlay.dart
+++ b/lib/ui/widgets/clock_overlay.dart
@@ -5,11 +5,13 @@ import 'package:flutter/material.dart';
 class ClockOverlay extends StatefulWidget {
   final String size; // 'small', 'medium', 'large'
   final String position; // 'bottomRight', 'bottomLeft', 'topRight', 'topLeft'
+  final bool useAmPm;
 
   const ClockOverlay({
     super.key,
     required this.size,
     required this.position,
+    required this.useAmPm,
   });
 
   @override
@@ -78,7 +80,14 @@ class _ClockOverlayState extends State<ClockOverlay> {
 
   @override
   Widget build(BuildContext context) {
-    final timeString = '${_now.hour.toString().padLeft(2, '0')}:${_now.minute.toString().padLeft(2, '0')}';
+    String timeString;
+    if (widget.useAmPm) {
+      final hour = _now.hour % 12 == 0 ? 12 : _now.hour % 12;
+      final amPm = _now.hour < 12 ? 'AM' : 'PM';
+      timeString = '$hour:${_now.minute.toString().padLeft(2, '0')} $amPm';
+    } else {
+      timeString = '${_now.hour.toString().padLeft(2, '0')}:${_now.minute.toString().padLeft(2, '0')}';
+    }
     
     return Align(
       alignment: _alignment,

--- a/test/infrastructure/repositories/hybrid_photo_repository_test.dart
+++ b/test/infrastructure/repositories/hybrid_photo_repository_test.dart
@@ -16,6 +16,9 @@ class FakeConfigProvider extends ChangeNotifier implements ConfigProvider {
   Future<void> save() async {}
 
   @override
+  bool useAmPm = false;
+
+  @override
   String get activeSourceType => '';
 
   @override

--- a/test/infrastructure/services/app_initializer_test.dart
+++ b/test/infrastructure/services/app_initializer_test.dart
@@ -22,6 +22,9 @@ class FakeConfigProvider extends ChangeNotifier implements ConfigProvider {
   Future<void> save() async {}
 
   @override
+  bool useAmPm = false;
+
+  @override
   String get activeSourceType => '';
 
   @override

--- a/test/infrastructure/services/photo_service_directory_change_test.dart
+++ b/test/infrastructure/services/photo_service_directory_change_test.dart
@@ -54,6 +54,9 @@ class MockConfigProvider extends ChangeNotifier implements ConfigProvider {
   String? get customPhotoPath => _customPhotoPath;
   
   @override
+  bool useAmPm = false;
+
+  @override
   set customPhotoPath(String? value) {
     _customPhotoPath = value;
     notifyListeners();


### PR DESCRIPTION
Used Jules to create this, please feel free voice any concerns and I'll do my best to fix them. There are [nightly releases](https://github.com/brad/OpenPhotoFrame/releases/tag/nightly-20260630) built by github actions in my clone if you wanna try

- Added useAmPm to ConfigProvider and implemented it in JsonConfigService.
- Added use_am_pm setting to assets/config.json.
- Added localization strings for useAmPm in English and German.
- Updated SettingsScreen to include a switch for AM/PM format under Clock settings.
- Updated ClockOverlay to format time in 12-hour format when useAmPm is true.
- Updated SlideshowScreen to pass the useAmPm setting to ClockOverlay.
- Fixed missing concrete implementations of useAmPm in test mocks.

# Preview
<img width="800" height="1340" alt="Screenshot_2026-06-29-18-08-07-133" src="https://github.com/user-attachments/assets/4642ae9f-48c5-4821-ad76-c4c5896e5c5e" />
